### PR TITLE
Donations

### DIFF
--- a/src/components/Landing.astro
+++ b/src/components/Landing.astro
@@ -21,7 +21,7 @@ import { Headline } from "./Headline";
       class="mt-2 text-2xl font-light leading-snug text-secondary md:text-3xl md:w-1/2"
     >
       <a href="https://linktr.ee/bliss_berlin" class="text-primary"
-        >Newsletter, Calendar, Slack, Applications and more</a
+        >Application, Calendar, Donations, Newsletter, Slack, and more</a
       >
     </p>
   </p>


### PR DESCRIPTION
Coming back to

> [18.11.25, 20:33:25] Justus: People asked me to donate but there is no link on the website. How do people donate?
> [18.11.25, 21:24:51] Jonas: Directly at the beginning of the website there is a link to linktree and on linktree there is a $ sign leading to paypal. But we should definitly improve this if people have trouble finding it
> [18.11.25, 22:34:55] Justus: Oh yes true! Maybe we can simply add "donations" in this list of things

I just did exactly that (and also sorted the keywords).

I think we can do better than this, but this could be one easy first step to make BLISS more self-financing.